### PR TITLE
(feat:actions) add set-default-labels action

### DIFF
--- a/.github/workflows/set-default-labels.yml
+++ b/.github/workflows/set-default-labels.yml
@@ -1,0 +1,22 @@
+name: set-default-labels
+
+on:
+  workflow_call:
+    inputs:
+      should-delete-labels:
+        description: 'Delete labels that are not in the list'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  set-default-labels:
+    name: SetDefaultLabels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1.0.0
+      - uses: lannonbr/issue-label-manager-action@3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          delete: ${{ inputs.should-delete-labels }}

--- a/README.md
+++ b/README.md
@@ -59,3 +59,55 @@ jobs:
     secrets:
       VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
 ```
+
+## set-default-labels
+
+The `set-default-labels` reusable action is located in `.github/workflows/set-default-labels.yml`.
+
+This reusable action depends on the following actions:
+
+- [checkout](https://github.com/marketplace/actions/checkout)
+- [lannonbr/issue-label-manager-action](https://github.com/marketplace/actions/issue-label-manager-action)
+
+### Usage
+
+In the repository that will call this action, you will need to create the following file: `.github/labels.json`. The content of the file can be something like the following:
+
+```json
+[
+  {"name": "bug", "color": "#d73a4a", "description": "something isn’t working" },
+  {"name": "chore", "color": "#fef2c0", "description": "keeping the lights on" }
+]
+```
+
+You can find more details about the above on the [issue-label-manager-action documentation](https://github.com/marketplace/actions/issue-label-manager-action#issue-label-manager-action). The next item you need to create in the repository that will call this action, is a workflow file. You can name the file `.github/workflows/set-default-labels.yml` and add the following content:
+
+```yml
+name: set-default-labels
+on: [workflow_dispatch]
+
+jobs:
+  set-default-labels:
+    uses:  project-calavera/calavera-reusable-actions/.github/workflows/set-default-labels.yml@main
+```
+
+### Inputs
+
+The action has the following inputs:
+
+#### should-delete-labels
+
+This is an optional `boolean` input that is `false` by default. If set to `true`, the action will delete any existing labels that are not listed in the JSON file mentioned previously.
+
+```yml
+name: set-default-labels
+on: [workflow_dispatch]
+
+jobs:
+  set-default-labels:
+    uses:  project-calavera/calavera-reusable-actions/.github/workflows/set-default-labels.yml@main
+    with:
+      should-delete-labels: true
+```
+
+Because of the nature of this action, it must be run manually. You can learn more about [manually running actions on GitHub](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).


### PR DESCRIPTION
Add a GitHub Action that when manually run, sets the default labels for the current repository.
